### PR TITLE
force buildroot commit rev to 982a61b6adabbcd68a0eb9ad1e348a732915e9e4

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ the Linux images to RAM and boot :)
 ```sh
 $ git clone http://github.com/buildroot/buildroot
 $ cd buildroot
+$ git checkout 982a61b6adabbcd68a0eb9ad1e348a732915e9e4
 $ cp -r ../linux-on-litex-vexriscv/buildroot/* ./
 $ make litex_vexriscv_defconfig
 $ make


### PR DESCRIPTION
newer builds break a clean build. rv32 is broken on linux-5.1.