### PR TITLE
linux: litex_liteuart: switch to liteuart in dts

### DIFF
--- a/buildroot/board/litex_vexriscv/litex_vexriscv_arty.dts
+++ b/buildroot/board/litex_vexriscv/litex_vexriscv_arty.dts
@@ -5,9 +5,13 @@
 	model = "VexRiscv SoCLinux on Digilent Arty Board";
 
 	chosen {
-		bootargs = "mem=128M@0x40000000 rootwait console=hvc0 root=/dev/ram0 init=/sbin/init swiotlb=32";
+		bootargs = "mem=128M@0x40000000 rootwait console=liteuart root=/dev/ram0 init=/sbin/init swiotlb=32";
 		linux,initrd-start = <0xC0800000>;
 		linux,initrd-end   = <0xC1000000>; // max 8MB ramdisk image
+	};
+
+	aliases {
+		serial0 = &liteuart0;
 	};
 
 	cpus {

--- a/buildroot/board/litex_vexriscv/litex_vexriscv_de0nano.dts
+++ b/buildroot/board/litex_vexriscv/litex_vexriscv_de0nano.dts
@@ -5,9 +5,13 @@
 	model = "VexRiscv SoCLinux on Terasic DE0-Nano Board";
 
 	chosen {
-		bootargs = "mem=32M@0x40000000 rootwait console=hvc0 root=/dev/ram0 init=/sbin/init swiotlb=32";
+		bootargs = "mem=32M@0x40000000 rootwait console=liteuart root=/dev/ram0 init=/sbin/init swiotlb=32";
 		linux,initrd-start = <0xC0800000>;
 		linux,initrd-end   = <0xC1000000>; // max 8MB ramdisk image
+	};
+
+	aliases {
+		serial0 = &liteuart0;
 	};
 
 	cpus {

--- a/buildroot/board/litex_vexriscv/litex_vexriscv_genesys2.dts
+++ b/buildroot/board/litex_vexriscv/litex_vexriscv_genesys2.dts
@@ -5,9 +5,13 @@
 	model = "VexRiscv SoCLinux on Digilent Genesys 2 Board";
 
 	chosen {
-		bootargs = "mem=128M@0x40000000 rootwait console=hvc0 root=/dev/ram0 init=/sbin/init swiotlb=32";
+		bootargs = "mem=128M@0x40000000 rootwait console=liteuart root=/dev/ram0 init=/sbin/init swiotlb=32";
 		linux,initrd-start = <0xC0800000>;
 		linux,initrd-end   = <0xC1000000>; // max 8MB ramdisk image
+	};
+
+	aliases {
+		serial0 = &liteuart0;
 	};
 
 	cpus {

--- a/buildroot/board/litex_vexriscv/litex_vexriscv_kcu105.dts
+++ b/buildroot/board/litex_vexriscv/litex_vexriscv_kcu105.dts
@@ -5,9 +5,13 @@
 	model = "VexRiscv SoCLinux on Xilinx KCU105 Board";
 
 	chosen {
-		bootargs = "mem=128M@0x40000000 rootwait console=hvc0 root=/dev/ram0 init=/sbin/init swiotlb=32";
+		bootargs = "mem=128M@0x40000000 rootwait console=liteuart root=/dev/ram0 init=/sbin/init swiotlb=32";
 		linux,initrd-start = <0xC0800000>;
 		linux,initrd-end   = <0xC1000000>; // max 8MB ramdisk image
+	};
+
+	aliases {
+		serial0 = &liteuart0;
 	};
 
 	cpus {

--- a/buildroot/board/litex_vexriscv/litex_vexriscv_minispartan6.dts
+++ b/buildroot/board/litex_vexriscv/litex_vexriscv_minispartan6.dts
@@ -5,9 +5,13 @@
 	model = "VexRiscv SoCLinux on Scarab Hardware miniSpartan6 Board";
 
 	chosen {
-		bootargs = "mem=32M@0x40000000 rootwait console=hvc0 root=/dev/ram0 init=/sbin/init swiotlb=32";
+		bootargs = "mem=32M@0x40000000 rootwait console=liteuart root=/dev/ram0 init=/sbin/init swiotlb=32";
 		linux,initrd-start = <0xC0800000>;
 		linux,initrd-end   = <0xC1000000>; // max 8MB ramdisk image
+	};
+
+	aliases {
+		serial0 = &liteuart0;
 	};
 
 	cpus {

--- a/buildroot/board/litex_vexriscv/litex_vexriscv_netv2.dts
+++ b/buildroot/board/litex_vexriscv/litex_vexriscv_netv2.dts
@@ -5,9 +5,13 @@
 	model = "VexRiscv SoCLinux on NeTV2 Board";
 
 	chosen {
-		bootargs = "mem=128M@0x40000000 rootwait console=hvc0 root=/dev/ram0 init=/sbin/init swiotlb=32";
+		bootargs = "mem=128M@0x40000000 rootwait console=liteuart root=/dev/ram0 init=/sbin/init swiotlb=32";
 		linux,initrd-start = <0xC0800000>;
 		linux,initrd-end   = <0xC1000000>; // max 8MB ramdisk image
+	};
+
+	aliases {
+		serial0 = &liteuart0;
 	};
 
 	cpus {

--- a/buildroot/board/litex_vexriscv/litex_vexriscv_nexys4ddr.dts
+++ b/buildroot/board/litex_vexriscv/litex_vexriscv_nexys4ddr.dts
@@ -5,9 +5,13 @@
 	model = "VexRiscv SoCLinux on Digilent Nexys 4 DDR Board";
 
 	chosen {
-		bootargs = "mem=128M@0x40000000 rootwait console=hvc0 root=/dev/ram0 init=/sbin/init swiotlb=32";
+		bootargs = "mem=128M@0x40000000 rootwait console=liteuart root=/dev/ram0 init=/sbin/init swiotlb=32";
 		linux,initrd-start = <0xC0800000>;
 		linux,initrd-end   = <0xC1000000>; // max 8MB ramdisk image
+	};
+
+	aliases {
+		serial0 = &liteuart0;
 	};
 
 	cpus {

--- a/buildroot/board/litex_vexriscv/litex_vexriscv_ulx3s.dts
+++ b/buildroot/board/litex_vexriscv/litex_vexriscv_ulx3s.dts
@@ -5,9 +5,13 @@
 	model = "VexRiscv SoCLinux on ULX3S Board";
 
 	chosen {
-		bootargs = "mem=32M@0x40000000 rootwait console=hvc0 root=/dev/ram0 init=/sbin/init swiotlb=32";
+		bootargs = "mem=32M@0x40000000 rootwait console=liteuart root=/dev/ram0 init=/sbin/init swiotlb=32";
 		linux,initrd-start = <0xC0800000>;
 		linux,initrd-end   = <0xC1000000>; // max 8MB ramdisk image
+	};
+
+	aliases {
+		serial0 = &liteuart0;
 	};
 
 	cpus {

--- a/buildroot/board/litex_vexriscv/litex_vexriscv_versa_ecp5.dts
+++ b/buildroot/board/litex_vexriscv/litex_vexriscv_versa_ecp5.dts
@@ -5,9 +5,13 @@
 	model = "VexRiscv SoCLinux on Versa ECP5 Board";
 
 	chosen {
-		bootargs = "mem=128M@0x40000000 rootwait console=hvc0 root=/dev/ram0 init=/sbin/init swiotlb=32";
+		bootargs = "mem=128M@0x40000000 rootwait console=liteuart root=/dev/ram0 init=/sbin/init swiotlb=32";
 		linux,initrd-start = <0xC0800000>;
 		linux,initrd-end   = <0xC1000000>; // max 8MB ramdisk image
+	};
+
+	aliases {
+		serial0 = &liteuart0;
 	};
 
 	cpus {


### PR DESCRIPTION
When adding litex_liteuart driver, it has only
been referenced in `litex_vexriscv.dts`. This commit
updtes other board-specific dts files.