### PR TITLE
add the Hackaday Supercon ECP5 badge

### DIFF
--- a/make.py
+++ b/make.py
@@ -160,6 +160,16 @@ class ULX3S(Board):
     def load(self):
         os.system("ujprog build/ulx3s/gateware/top.svf")
 
+# HADBadge support ------------------------------------------------------------------------------------
+
+class HADBadge(Board):
+    def __init__(self):
+        from litex_boards.targets import hadbadge
+        Board.__init__(self, hadbadge.BaseSoC, {"serial"})
+
+    def load(self):
+        os.system("dfu-util --alt 2 --download build/hadbadge/gateware/top.bit --reset")
+
 # OrangeCrab support ------------------------------------------------------------------------------------
 
 class OrangeCrab(Board):
@@ -209,6 +219,7 @@ supported_boards = {
     # Lattice
     "versa_ecp5":   VersaECP5,
     "ulx3s":        ULX3S,
+    "hadbadge":     HADBadge,
     "orangecrab":   OrangeCrab,
     # Altera/Intel
     "de0nano":      De0Nano,
@@ -240,7 +251,7 @@ def main():
     for board_name in board_names:
         board = supported_boards[board_name]()
         soc_kwargs = {}
-        if board_name in ["versa_ecp5", "ulx3s", "orangecrab"]:
+        if board_name in ["versa_ecp5", "ulx3s", "hadbadge", "orangecrab"]:
             soc_kwargs["toolchain"] = "trellis"
             soc_kwargs["cpu_variant"] = "linux+no-dsp"
         if board_name in ["de0nano"]:


### PR DESCRIPTION
Add the [Hackaday Supercon 2019 badge](https://hackaday.io/project/167255-2019-hackaday-superconference-badge) which has an ECP5 FPGA.

These changes are from [a fork](https://github.com/mwelling/linux-on-litex-vexriscv) by Michael Welling (@mwelling)

During Supercon, we tried two approaches:
- use the built-in 16MB QSPI SRAM
- use add-on cartiridge with 32MB SDRAM by Jacob Creedon

We were not able to get the QSPI SRAM working so I've removed those changes, and I have just added the changes that are needed to boot Linux with the 32MB SDRAM.

In addition to @mwelling, thank you to Jacob Creedon (@jcreedon), @GregDavill, Tim Ansell (@mithro), and Sean Cross (@xobs) who all helped get Linux working on this badge.

KiCad design files by @jcreedon for the SDRAM cartridge are [available on GitHub](https://github.com/jcreedon/dram-cart/).

There is also a [shared project](https://oshpark.com/shared_projects/IQSl2lid) to order the SDRAM cartridge PCB.

Refer to [my blog post](https://blog.oshpark.com/2019/12/20/boot-linux-on-this-hackaday-supercon-badge-with-this-sdram-cartridge/) for more information.

Finally, the Hackaday Supercon badge schematic and PCB layout are on [GitHub too](https://github.com/Spritetm/hadbadge2019_pcb).