### PR TITLE
soc_linux: fix max_sdram_size value

### DIFF
--- a/soc_linux.py
+++ b/soc_linux.py
@@ -57,7 +57,7 @@ def SoCLinux(soc_cls, **kwargs):
                 cpu_type       = "vexriscv",
                 cpu_variant    = cpu_variant,
                 uart_baudrate  = 1e6,
-                max_sdram_size = 0x1000000, # Limit mapped SDRAM to 256MB for now
+                max_sdram_size = 0x10000000, # Limit mapped SDRAM to 256MB for now
                 **kwargs)
 
             # machine mode emulator ram


### PR DESCRIPTION
It was 16MB instead of 256MB.