### PR TITLE
travis: add simulated sdram test

### DIFF
--- a/.sim-test.py
+++ b/.sim-test.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+import os
+import sys
+import pexpect
+import time
+from argparse import ArgumentParser
+
+
+parser = ArgumentParser()
+parser.add_argument("--sdram-module", type=str)
+args = parser.parse_args()
+
+
+tests = [
+    {
+        'id':      'linux-on-litex-vexriscv',
+        'command': f'./sim.py --with-sdram --sdram-module {args.sdram_module}',
+        'cwd':     os.getcwd(),
+        'checkpoints': [
+            { 'timeout': 240,  'good': [b'\n\\s*BIOS built on'] },
+            { 'timeout': 60,   'good': [b'\n\\s*VexRiscv Machine Mode software'] },
+            { 'timeout': 240,  'good': [b'Memory: \\d+K/\\d+K available'] },
+        ]
+    }
+]
+
+
+def run_test(id, command, cwd, checkpoints):
+    print(f'*** Test ID: {id}')
+    print(f'*** CWD:     {cwd}')
+    print(f'*** Command: {command}')
+    os.chdir(cwd)
+    p = pexpect.spawn(command, timeout=None, logfile=sys.stdout.buffer)
+
+    checkpoint_id = 0
+    for cp in checkpoints:
+        good = cp.get('good', [])
+        bad = cp.get('bad', [])
+        patterns = good + bad
+        timeout = cp.get('timeout', None)
+
+        timediff = time.time()
+        try:
+            match_id = p.expect(patterns, timeout=timeout)
+        except pexpect.EOF:
+            print(f'\n*** {id}: premature termination')
+            return False;
+        except pexpect.TIMEOUT:
+            timediff = time.time() - timediff
+            print(f'\n*** {id}: timeout (checkpoint {checkpoint_id}: +{int(timediff)}s)')
+            return False;
+        timediff = time.time() - timediff
+
+        if match_id >= len(good):
+            break
+
+        sys.stdout.buffer.write(b'<<checkpoint %d: +%ds>>' % (checkpoint_id, int(timediff)))
+        checkpoint_id += 1
+
+    is_success = checkpoint_id == len(checkpoints)
+
+    # Let it print rest of line
+    match_id = p.expect_exact([b'\n', pexpect.TIMEOUT, pexpect.EOF], timeout=1)
+    p.terminate(force=True)
+
+    line_break = '\n' if match_id != 0 else ''
+    print(f'{line_break}*** {id}: {"success" if is_success else "failure"}')
+
+    return is_success
+
+
+for test in tests:
+    success = run_test(**test)
+    if not success:
+        sys.exit(1)
+
+sys.exit(0)
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,15 @@ install:
  - conda activate linux-on-litex-vexriscv
  - conda info
  - ./make.py --help
+ - if [[ -v SDRAM_MODULE ]]; then git clone --depth 1 https://github.com/litex-hub/linux-on-litex-vexriscv-prebuilt.git; fi
+ - if [[ -v SDRAM_MODULE ]]; then cp -R linux-on-litex-vexriscv-prebuilt/buildroot ./; fi
 
 script:
- - ./make.py --board="$BOARD"
+ - if [[ -v BOARD        ]]; then ./make.py --board="$BOARD"; fi
+ - if [[ -v SDRAM_MODULE ]]; then ./.sim-test.py --sdram-module="$SDRAM_MODULE"; fi
 
 env:
+ # ----- BOARDS -----
  # TOOLCHAIN=vivado
  - BOARD=Arty
  - BOARD=NeTV2
@@ -43,3 +47,36 @@ env:
  - BOARD=De10Lite
  # TOOLCHAIN=libero
  #- BOARD=Avalanche
+
+ # ----- SIMULATIONS -----
+ - SDRAM_MODULE=IS42S16160
+ - SDRAM_MODULE=IS42S16320
+ #- SDRAM_MODULE=MT48LC4M16  # Too small for Linux
+ - SDRAM_MODULE=MT48LC16M16
+ - SDRAM_MODULE=AS4C16M16
+ - SDRAM_MODULE=AS4C32M16
+ - SDRAM_MODULE=AS4C32M8
+ #- SDRAM_MODULE=M12L64322A  # Too small for Linux
+ #- SDRAM_MODULE=M12L16161A  # Too small for Linux
+ - SDRAM_MODULE=MT46V32M16
+ - SDRAM_MODULE=MT46H32M16
+ - SDRAM_MODULE=MT46H32M32
+ - SDRAM_MODULE=MT47H128M8
+ - SDRAM_MODULE=MT47H32M16
+ - SDRAM_MODULE=MT47H64M16
+ - SDRAM_MODULE=P3R1GE4JGF
+ - SDRAM_MODULE=MT41K64M16
+ - SDRAM_MODULE=MT41J128M16
+ - SDRAM_MODULE=MT41J256M16
+ - SDRAM_MODULE=K4B1G0446F
+ - SDRAM_MODULE=K4B2G1646F
+ - SDRAM_MODULE=H5TC4G63CFR
+ - SDRAM_MODULE=IS43TR16128B
+ - SDRAM_MODULE=MT8JTF12864
+ - SDRAM_MODULE=MT8KTF51264
+ - SDRAM_MODULE=MT18KSF1G72HZ
+ - SDRAM_MODULE=AS4C256M16D3A
+ - SDRAM_MODULE=MT16KTF1G64HZ
+ - SDRAM_MODULE=EDY4016A
+ - SDRAM_MODULE=MT40A1G8
+ - SDRAM_MODULE=MT40A512M16

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -8,6 +8,8 @@ dependencies:
   - nextpnr-ecp5
   - openocd
   - verilator
+  - libevent
+  - json-c
   - yosys
   - pip
   - pip:                            # Packages installed from PyPI

--- a/conda/requirements.txt
+++ b/conda/requirements.txt
@@ -4,4 +4,6 @@
 -e git+https://github.com/enjoy-digital/litedram@master#egg=litedram
 -e git+https://github.com/enjoy-digital/litesdcard@master#egg=litesdcard
 -e git+https://github.com/enjoy-digital/litevideo@master#egg=litevideo
+-e git+https://github.com/enjoy-digital/litescope@master#egg=litescope
 -e git+https://github.com/litex-hub/litex-boards@master#egg=litex-boards
+pexpect


### PR DESCRIPTION
Simulations pass with https://github.com/litex-hub/linux-on-litex-vexriscv/pull/96 and https://github.com/litex-hub/linux-on-litex-vexriscv/pull/100 applied.
Failures for Arty, Versa ECP5, or NeTV2 reported in https://github.com/litex-hub/linux-on-litex-vexriscv/issues/101.

