### PR TITLE
confirm SPI flash settings for HADBadge

### DIFF
--- a/make.py
+++ b/make.py
@@ -179,8 +179,8 @@ class ULX3S(Board):
 # HADBadge support ---------------------------------------------------------------------------------
 
 class HADBadge(Board):
-    SPIFLASH_PAGE_SIZE    = 256   # CHECKME
-    SPIFLASH_SECTOR_SIZE  = 64*kB # CHECKME
+    SPIFLASH_PAGE_SIZE    = 256
+    SPIFLASH_SECTOR_SIZE  = 64*kB
     SPIFLASH_DUMMY_CYCLES = 8
     def __init__(self):
         from litex_boards.targets import hadbadge


### PR DESCRIPTION
SPIFLASH_PAGE_SIZE. SPIFLASH_SECTOR_SIZE and dummy bytes is working ok for the Hackaday Badge (ECP5).

LiteX BIOS can read the SPI Flash ok:
```
litex> mr 0xd0000000 128
Memory dump:
0xd0000000  00 50 61 72 74 3a 20 4c 46 45 35 55 2d 34 35 46  .Part: LFE5U-45F
0xd0000010  2d 38 43 41 42 47 41 33 38 31 00 ff ff ff bd b3  -8CABGA381......
0xd0000020  ff ff ff ff 3b 00 00 00 e2 00 00 00 41 11 20 43  ....;.......A. C
0xd0000030  22 00 00 00 40 00 00 00 46 00 00 00 82 91 24 fe  "...@...F.....$.
0xd0000040  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0xd0000050  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0xd0000060  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0xd0000070  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
```