### PR TITLE
emulator: enable LTO

### DIFF
--- a/emulator/Makefile
+++ b/emulator/Makefile
@@ -16,7 +16,7 @@ all: emulator.bin
 	chmod -x $@
 
 emulator.elf: $(OBJECTS)
-	$(LD) $(LDFLAGS) \
+	$(CC) $(LDFLAGS) \
 		-T linker.ld \
 		-N -o $@ \
 		 $(BUILD_DIR)/software/libbase/crt0-$(CPU)-ctr.o \

--- a/emulator/main.c
+++ b/emulator/main.c
@@ -351,7 +351,7 @@ static uint32_t vexriscv_read_instruction(uint32_t pc){
 }
 
 
-void vexriscv_machine_mode_trap(void) {
+__attribute__((used)) void vexriscv_machine_mode_trap(void) {
 	int32_t cause = csr_read(mcause);
 
 	/* Interrupt */


### PR DESCRIPTION
The changes are required because LiteX software
is now built with LTO (Linker Time Optimization).

For details see: https://github.com/enjoy-digital/litex/pull/401.