### PR TITLE
make: add ZCU104 board

### DIFF
--- a/make.py
+++ b/make.py
@@ -106,6 +106,19 @@ class KCU105(Board):
         prog.load_bitstream("build/kcu105/gateware/top.bit")
 
 
+# ZCU104 support -----------------------------------------------------------------------------------
+
+class ZCU104(Board):
+    def __init__(self):
+        from litex_boards.targets import zcu104
+        Board.__init__(self, zcu104.BaseSoC, {"serial"})
+
+    def load(self):
+        from litex.build.xilinx import VivadoProgrammer
+        prog = VivadoProgrammer()
+        prog.load_bitstream("build/zcu104/gateware/top.bit")
+
+
 # Nexys4DDR support --------------------------------------------------------------------------------
 
 class Nexys4DDR(Board):
@@ -253,6 +266,7 @@ supported_boards = {
     "genesys2":     Genesys2,
     "kc705":        KC705,
     "kcu105":       KCU105,
+    "zcu104":       ZCU104,
     "nexys4ddr":    Nexys4DDR,
     "nexys_video":  NexysVideo,
     "minispartan6": MiniSpartan6,


### PR DESCRIPTION
Depends on litex-hub/litex-boards#47
At this point LiteDRAM can only use half of the data bus (32-bit instead of 64-bit) but after disabling the other half Linux boots successfully on this board