### PR TITLE
emulator: Implement SBI_EXT_BASE syscall.

### DIFF
--- a/emulator/riscv.h
+++ b/emulator/riscv.h
@@ -83,6 +83,15 @@
 #define SBI_REMOTE_SFENCE_VMA      6
 #define SBI_REMOTE_SFENCE_VMA_ASID 7
 #define SBI_SHUTDOWN               8
+#define SBI_EXT_BASE               16
+
+#define SBI_EXT_SPEC_VERSION       0
+#define SBI_EXT_IMPL_ID            1
+#define SBI_EXT_IMPL_VERSION       2
+#define SBI_EXT_PROBE_EXTENSION    3
+#define SBI_EXT_GET_MVENDORID      4
+#define SBI_EXT_GET_MARCHID        5
+#define SBI_EXT_GET_MIMPID         6
 
 #define csr_swap(csr, val)					\
 ({								\


### PR DESCRIPTION
In trying to boot a v5.8 kernel, it seems that the kernel is attempting to discover the SBI version using the SBI_EXT_BASE syscall, but this is resulting in a hung board due to the default case in the SBI syscall hander doing a litex_stop(). I think the kernel is expecting the SBI syscall to return an error if not supported in this case.

This patch should workaround the issue in two ways: first we implement the SBI_EXT_BASE syscall to report our version as v0.1, and we also change the default case to return an error instead of halting the CPU.