### PR TITLE
sim: Fix csr.json not found error

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -229,7 +229,6 @@ def main():
             trace_start = int(args.trace_start),
             trace_end   = int(args.trace_end))
         if i == 0:
-            os.chdir("..")
             soc.generate_dts(board_name)
             soc.compile_dts(board_name)
             soc.compile_emulator(board_name)


### PR DESCRIPTION
When running the simulator in the project directory, as instructed by
README.md:

    $ ./sim.py
    ...
    Traceback (most recent call last):
      File "./sim.py", line 242, in <module>
	main()
      File "./sim.py", line 236, in main
	soc.generate_dts(board_name)
      File "./sim.py", line 176, in generate_dts
	with open(json_src) as json_file, open(dts, "w") as dts_file:
    FileNotFoundError: [Errno 2] No such file or directory: 'build/sim/csr.json'

Due to the os.chdir(), the current directory is changed to the parent
directory of the project, and the csr.json file cannot be found.

Fix this dropping the os.chdir() call.

Fixes: acffa47e621e11f8 ("add dts auto-generation with litex json export and initial json2dts.py script")
Signed-off-by: Geert Uytterhoeven <geert@linux-m68k.org>