### PR TITLE
make: OrangeCrab: Fix sys_clk_freq

### DIFF
--- a/make.py
+++ b/make.py
@@ -262,7 +262,7 @@ class HADBadge(Board):
 
 class OrangeCrab(Board):
     soc_kwargs = {
-        "sys_clk_freq": 64e6,          # Increase sys_clk_freq to 64MHz (48MHz default).
+        "sys_clk_freq": int(64e6),     # Increase sys_clk_freq to 64MHz (48MHz default).
         "l2_size":      2048,          # Reduce l2_size (Not enough blockrams).
         "integrated_rom_size": 0xa000, # Reduce integrated_rom_size.
     }


### PR DESCRIPTION
When building for OrangeCrab:

    $ ./make.py --board=orangecrab --build
    ...
    Traceback (most recent call last):
      File "./make.py", line 492, in <module>
	main()
      File "./make.py", line 431, in main
	soc = SoCLinux(board.soc_cls, **soc_kwargs)
      File "/path/to/linux-on-litex-vexriscv/soc_linux.py", line 283, in SoCLinux
	return _SoCLinux(**kwargs)
      File "/path/to/linux-on-litex-vexriscv/soc_linux.py", line 111, in __init__
	**kwargs)
      File "/path/to/litex/litex-boards/litex_boards/targets/orangecrab.py", line 166, in __init__
	self.submodules.crg = crg_cls(platform, sys_clk_freq, with_usb_pll)
      File "/path/to/litex/litex-boards/litex_boards/targets/orangecrab.py", line 137, in __init__
	reset_timer = WaitTimer(sys_clk_freq)
      File "/path/to/litex/migen/migen/genlib/misc.py", line 83, in __init__
	count = Signal(bits_for(t), reset=t)
      File "/path/to/litex/migen/migen/fhdl/bitcontainer.py", line 18, in bits_for
	r = log2_int(n + 1, False)
      File "/path/to/litex/migen/migen/fhdl/bitcontainer.py", line 10, in log2_int
	r = (n - 1).bit_length()
    AttributeError: 'float' object has no attribute 'bit_length'

Fix this by converting the clock frequency to an integer before
assigning it to sys_clk_freq, like most targets in the litex_boards
repository (incl. orangecrab.py) do.

Fixes: f0168c146b304ed8 ("make: adjust integrated_rom_size and set sys_clk_freq to 64MHz on OrangeCrab.")
Signed-off-by: Geert Uytterhoeven <geert@linux-m68k.org>