### PR TITLE
add Qmtech EP4CE15 coreboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This project demonstrates **how high level HDLs (Spinal HDL, Migen) enable new p
 | De10Lite     | Intel MAX10         | 10M50DA       |     50MHz     | 16-bits  64MB SDR  |      No       |         No         |   No   |
 | De10Nano     | Intel Cyclone5      | 5CSEBA6U23I7  |     50MHz     | 16-bits  32MB SDR  |      No       |         No         |   Yes  |
 | Avalanche    | Microsemi PolarFire | MPF300TS      |    100MHz     | 16-bits 256MB DDR3 |   8MB QSPI*   |   1Gbps RGMII*     |   No   |
+| QM T ep4ce15 | Intel Cyclone4      | EP4CE15F      |     50MHz     | 16-bits  32MB SDR  |      No       |         No         |   No   |
 
 > **Note:** \*=present on the board but not yet supported.
 

--- a/make.py
+++ b/make.py
@@ -356,6 +356,21 @@ class De0Nano(Board):
             "serial",
         }, bitstream_ext=".sof")
 
+# qmtech EP4CE15 support ----------------------------------------------------------------------------------
+
+class Qmtech_EP4CE15(Board):
+    soc_kwargs = {
+        "l2_size":      1024,          # Reduce l2_size (Not enough blockrams).
+        "integrated_rom_size": 0x8000, # Reduce integrated_rom_size.
+    }
+    def __init__(self):
+        from litex_boards.targets import qmtech_EP4CE15
+        Board.__init__(self, qmtech_EP4CE15.BaseSoC, soc_capabilities={
+            # Communication
+            "serial",
+            # "leds",
+        }, bitstream_ext=".sof")
+
 # Main ---------------------------------------------------------------------------------------------
 
 supported_boards = {
@@ -386,6 +401,8 @@ supported_boards = {
     "de0nano":      De0Nano,
     "de10lite":     De10Lite,
     "de10nano":     De10Nano,
+
+    "qmtech_ep4ce15":      Qmtech_EP4CE15,
 }
 
 def main():

--- a/make.py
+++ b/make.py
@@ -360,7 +360,8 @@ class De0Nano(Board):
 
 class Qmtech_EP4CE15(Board):
     soc_kwargs = {
-        "l2_size":      1024,          # Reduce l2_size (Not enough blockrams).
+        "l2_size":      2048,          # Reduce l2_size (Not enough blockrams).
+        "integrated_sram_size": 0x800,
         "integrated_rom_size": 0x8000, # Reduce integrated_rom_size.
     }
     def __init__(self):


### PR DESCRIPTION
Works perfectly
```
[LXTERM] Starting....
�
        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
   Build your hardware, easily!

 (c) Copyright 2012-2020 Enjoy-Digital
 (c) Copyright 2007-2015 M-Labs

 BIOS built on Nov 12 2020 11:54:25
 BIOS CRC passed (4972a288)

 Migen git sha1: a5cc037
 LiteX git sha1: 9c0f6879

--=============== SoC ==================--
CPU:		VexRiscv_Linux @ 50MHz
BUS:		WISHBONE 32-bit @ 4GiB
CSR:		8-bit data
ROM:		32KiB
SRAM:		2KiB
L2:		2KiB
SDRAM:		32768KiB 16-bit @ 50MT/s (CL-2 CWL-2)

--========== Initialization ============--
Initializing SDRAM @0x40000000...
Switching SDRAM to software control.
Switching SDRAM to hardware control.
Memtest at 0x40000000 (2MiB)...
  Write: 0x40000000-0x40200000 2MiB     
   Read: 0x40000000-0x40200000 2MiB     
Memtest OK
Memspeed at 0x40000000 (2MiB)...
  Write speed: 12MiB/s
   Read speed: 10MiB/s

--============== Boot ==================--
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
[LXTERM] Received firmware download request from the device.
[LXTERM] Uploading buildroot/Image to 0x40000000 (4545524 bytes)...
[LXTERM] Upload complete (80.0KB/s).
[LXTERM] Uploading buildroot/rootfs.cpio to 0x40800000 (8029184 bytes)...
[LXTERM] Upload complete (79.7KB/s).
[LXTERM] Uploading buildroot/rv32.dtb to 0x41000000 (1891 bytes)...
[LXTERM] Upload complete (80.3KB/s).
[LXTERM] Uploading emulator/emulator.bin to 0x41100000 (9724 bytes)...
[LXTERM] Upload complete (79.9KB/s).
[LXTERM] Booting the device.
[LXTERM] Done.
KExecuting booted program at 0x41100000

--============= Liftoff! ===============--
VexRiscv Machine Mode software built Nov 12 2020 11:58:59
--========== Booting Linux =============--
[    0.000000] No DTB passed to the kernel
[    0.000000] Linux version 5.0.13 (florent@lab) (gcc version 8.3.0 (Buildroot 2019.08-rc2-00011-gad9efda578)) #1 Thu Sep 12 14:20:26 CEST 2019
[    0.000000] earlycon: sbi0 at I/O port 0x0 (options '')
[    0.000000] printk: bootconsole [sbi0] enabled
[    0.000000] Initial ramdisk at: 0x(ptrval) (8388608 bytes)
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000040000000-0x0000000041ffffff]
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000040000000-0x0000000041ffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x0000000041ffffff]
[    0.000000] elf_hwcap is 0x1101
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 8128
[    0.000000] Kernel command line: mem=32M@0x40000000 rootwait console=liteuart earlycon=sbi root=/dev/ram0 init=/sbin/init swiotlb=32
[    0.000000] Dentry cache hash table entries: 4096 (order: 2, 16384 bytes)
[    0.000000] Inode-cache hash table entries: 2048 (order: 1, 8192 bytes)
[    0.000000] Sorting __ex_table...
[    0.000000] Memory: 19796K/32768K available (3415K kernel code, 148K rwdata, 509K rodata, 140K init, 216K bss, 12972K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
[    0.000000] NR_IRQS: 0, nr_irqs: 0, preallocated irqs: 0
[    0.000000] clocksource: riscv_clocksource: mask: 0xffffffffffffffff max_cycles: 0xb8812736b, max_idle_ns: 440795202655 ns
[    0.000540] sched_clock: 64 bits at 50MHz, resolution 20ns, wraps every 4398046511100ns
[    0.005726] Console: colour dummy device 80x25
[    0.008833] Calibrating delay loop (skipped), value calculated using timer frequency.. 100.00 BogoMIPS (lpj=200000)
[    0.011109] pid_max: default: 32768 minimum: 301
[    0.030169] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes)
[    0.032945] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes)
[    0.141581] devtmpfs: initialized
[    0.222261] random: get_random_bytes called from setup_net+0x4c/0x188 with crng_init=0
[    0.235382] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
[    0.237607] futex hash table entries: 256 (order: -1, 3072 bytes)
[    0.259021] NET: Registered protocol family 16
[    0.682393] clocksource: Switched to clocksource riscv_clocksource
[    1.313904] NET: Registered protocol family 2
[    1.347619] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 4096 bytes)
[    1.350160] TCP established hash table entries: 1024 (order: 0, 4096 bytes)
[    1.353203] TCP bind hash table entries: 1024 (order: 0, 4096 bytes)
[    1.355867] TCP: Hash tables configured (established 1024 bind 1024)
[    1.363617] UDP hash table entries: 256 (order: 0, 4096 bytes)
[    1.365702] UDP-Lite hash table entries: 256 (order: 0, 4096 bytes)
[    1.401596] Unpacking initramfs...
[    6.103894] Initramfs unpacking failed: junk in compressed archive
[    6.151371] workingset: timestamp_bits=30 max_order=13 bucket_order=0
[    7.328716] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 253)
[    7.331142] io scheduler mq-deadline registered
[    7.332399] io scheduler kyber registered
[   11.257781] f0001000.serial: ttyLXU0 at MMIO 0xf0001000 (irq = 0, base_baud = 0) is a liteuart
[   11.261006] printk: console [liteuart0] enabled
[   11.261006] printk: console [liteuart0] enabled
[   11.263552] printk: bootconsole [sbi0] disabled
[   11.263552] printk: bootconsole [sbi0] disabled
[   11.328686] libphy: Fixed MDIO Bus: probed
[   11.343175] i2c /dev entries driver
[   11.488928] NET: Registered protocol family 10
[   11.537155] Segment Routing with IPv6
[   11.543202] sit: IPv6, IPv4 and MPLS over IPv4 tunneling driver
[   11.657158] Freeing unused kernel memory: 140K
[   11.659017] This architecture does not have kernel memory protection.
[   11.660254] Run /init as init process
mount: mounting tmpfs on /dev/shm failed: Invalid argument
mount: mounting tmpfs on /tmp failed: Invalid argument
mount: mounting tmpfs on /run failed: Invalid argument
Starting syslogd: OK
Starting klogd: OK
Running sysctl: OK
Initializing random number generator... [   18.969930] random: dd: uninitialized urandom read (512 bytes read)
done.
Starting network: OK
Starting dropbear sshd: [   22.640028] random: dropbear: uninitialized urandom read (32 bytes read)
OK

Welcome to Buildroot
buildroot login: 


```