### PR TITLE
make/orangecrab: Enable I2C

### DIFF
--- a/make.py
+++ b/make.py
@@ -305,6 +305,8 @@ class OrangeCrab(Board):
         Board.__init__(self, orangecrab.BaseSoC, soc_capabilities={
             # Communication
             "usb_acm",
+            # Buses
+            "i2c",
             # Storage
             "spisdcard",
         }, bitstream_ext=".bit")
@@ -505,6 +507,10 @@ def main():
         if board_name in ["arty", "arty_a7"]:
             from litex_boards.platforms.arty import _sdcard_pmod_io
             board.platform.add_extension(_sdcard_pmod_io)
+
+        if board_name in ["orangecrab"]:
+            from litex_boards.platforms.orangecrab import feather_i2c
+            board.platform.add_extension(feather_i2c)
 
         if "mmcm" in board.soc_capabilities:
             soc.add_mmcm(2)


### PR DESCRIPTION
Enable I2C on the Feather expansion connector, so Linux can access
I2C devices on FeatherWings.

Example i2cdetect output with Adafruit 0.54" Quad Alphanumeric
FeatherWing Display installed:

    root@buildroot:~# i2cdetect -y -a 0
	 0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
    00: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
    10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
    20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
    30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
    40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
    50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
    60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
    70: 70 -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
    root@buildroot:~#

Signed-off-by: Geert Uytterhoeven <geert@linux-m68k.org>