### PR TITLE
make/colorlight_i5: set bitstream_ext to .bit instead of .svf.

### DIFF
--- a/make.py
+++ b/make.py
@@ -381,7 +381,7 @@ class Colorlight_i5(Board):
             # Communication
             "serial",
             "ethernet",
-        }, bitstream_ext=".svf")
+        }, bitstream_ext=".bit")
 
 #---------------------------------------------------------------------------------------------------
 # Intel Boards


### PR DESCRIPTION
Hi,

This fixes the loading issue on colorlight i5 which is similar to
https://github.com/litex-hub/litex-boards/pull/169#issue-566422928

Regards,
    kaz
