### PR TITLE
Add serial-boot flag for loading linux images

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ All the boards support Serial loading of the Linux images and this is the only w
 
 To load the Linux images over Serial, use the [lxterm](https://github.com/enjoy-digital/litex/blob/master/litex/tools/litex_term.py) terminal/tool provided by LiteX and run:
 ```sh
-$ lxterm --images=images/boot.json /dev/ttyUSBX --speed=1e6
+$ lxterm --images=images/boot.json /dev/ttyUSBX --speed=1e6 --serial-boot
 ```
 The images should load and you should see Linux booting :)
 


### PR DESCRIPTION
Updates the lxterm command to use serial-boot flag to load and boot
linux images.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

This appears to be required. I am testing on the Digilent Arty A7.