### PR TITLE
make.py: fix flash

### DIFF
--- a/make.py
+++ b/make.py
@@ -26,7 +26,7 @@ class Board:
 
     def flash(self, filename):
         prog = self.platform.create_programmer()
-        prog.flash(None, filename)
+        prog.flash(0, filename)
 
 #---------------------------------------------------------------------------------------------------
 # Xilinx Boards


### PR DESCRIPTION
Formerly this caused a type error in `openocd.py`:
```
  File ".../litex/linux-on-litex-vexriscv/./make.py", line 30, in flash
    prog.flash(None, filename)
  File ".../litex/litex/litex/build/openocd.py", line 36, in flash
    "jtagspi_program {{{}}} 0x{:x}".format(data, address),
TypeError: unsupported format string passed to NoneType.__format__
```