### PR TITLE
make/soc_linux: Add support for FDT Overlays

### DIFF
--- a/make.py
+++ b/make.py
@@ -506,6 +506,7 @@ def main():
     parser.add_argument("--remote-ip",      default="192.168.1.100",  help="Remote IP address of TFTP server")
     parser.add_argument("--spi-data-width", type=int, default=8,      help="SPI data width (maximum transfered bits per xfer)")
     parser.add_argument("--spi-clk-freq",   type=int, default=1e6,    help="SPI clock frequency")
+    parser.add_argument("--fdtoverlays",    default="",               help="Device Tree Overlays to apply")
     VexRiscvSMP.args_fill(parser)
     args = parser.parse_args()
 
@@ -599,7 +600,10 @@ def main():
 
         # DTS --------------------------------------------------------------------------------------
         soc.generate_dts(board_name)
-        soc.compile_dts(board_name)
+        soc.compile_dts(board_name, args.fdtoverlays)
+
+        # DTB --------------------------------------------------------------------------------------
+        soc.combine_dtb(board_name, args.fdtoverlays)
 
         # Load FPGA bitstream ----------------------------------------------------------------------
         if args.load:

--- a/soc_linux.py
+++ b/soc_linux.py
@@ -2,6 +2,7 @@
 
 import os
 import json
+import shutil
 import subprocess
 
 from litex.soc.cores.cpu import VexRiscvSMP
@@ -188,11 +189,21 @@ def SoCLinux(soc_cls, **kwargs):
                 dts_file.write(dts_content)
 
         # DTS compilation --------------------------------------------------------------------------
-        def compile_dts(self, board_name):
+        def compile_dts(self, board_name, symbols=False):
             dts = os.path.join("build", board_name, "{}.dts".format(board_name))
-            dtb = os.path.join("images", "rv32.dtb")
+            dtb = os.path.join("build", board_name, "{}.dtb".format(board_name))
             subprocess.check_call(
-                "dtc -O dtb -o {} {}".format(dtb, dts), shell=True)
+                "dtc {} -O dtb -o {} {}".format("-@" if symbols else "", dtb, dts), shell=True)
+
+        # DTB combination --------------------------------------------------------------------------
+        def combine_dtb(self, board_name, overlays=""):
+            dtb_in = os.path.join("build", board_name, "{}.dtb".format(board_name))
+            dtb_out = os.path.join("images", "rv32.dtb")
+            if overlays == "":
+                shutil.copyfile(dtb_in, dtb_out)
+            else:
+                subprocess.check_call(
+                    "fdtoverlay -i {} -o {} {}".format(dtb_in, dtb_out, overlays), shell=True)
 
         # Documentation generation -----------------------------------------------------------------
         def generate_doc(self, board_name):


### PR DESCRIPTION
FPGA development boards typically have many expansion connectors, while
the board DTS as generated by LiteX describes only a part of the
system.

Add support for describing hardware connected to expansion connectors
using Flattened Device Tree Overlays.

Generation of the final DTB is done in two steps:
  1. Compile the board DTS into a board DTB, with or without symbols,
     depending on the presence of overlays,
  2. Combine the board DTB and all specified overlays (if any) into the
     final rv32.dtb using fdtoverlay.
     If no overlays are specified, a shortcut is taken by just copying
     the DTB, to avoid relying on the fdtoverlay tool being installed.

Example:

    ./make.py --board=orangecrab --cpu-count=1 --load --fdtoverlays="adafruit-featherwing-quad-alphanumeric-red.dtbo adafruit-featherwing-oled.dtbo"

Signed-off-by: Geert Uytterhoeven <geert@linux-m68k.org>