### PR TITLE
ci: use HDL container to prepare for bitstream building

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,19 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-18.04
+    container:
+      image: ghcr.io/hdl/debian-buster/impl:prjtrellis
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - board: 'arty'
+            args: ''
+          - board: 'trellisboard'
+            args: ''
+          - board: 'ecpix5'
+            args: ''
+          - board: 'de10nano'
     steps:
       # Checkout Repository
       - name: Checkout
@@ -13,27 +26,33 @@ jobs:
       # Install Tools
       - name: Install Tools
         run: |
-          sudo apt-get install wget build-essential python3 verilator libevent-dev libjson-c-dev device-tree-compiler
-          pip3 install setuptools
-          pip3 install requests
-          pip3 install pexpect
+          apt-get -qy update
+          apt-get -qy install wget build-essential python3 python3-pip verilator libevent-dev libjson-c-dev \
+            device-tree-compiler python3-requests python3-pexpect
 
       # Install (n)Migen / LiteX / Cores
       - name: Install LiteX
         run: |
           wget https://raw.githubusercontent.com/enjoy-digital/litex/master/litex_setup.py
-          python3 litex_setup.py init install --user
+          python3 litex_setup.py init install
 
       # Install RISC-V GCC
       - name: Install RISC-V GCC
         run: |
-          wget https://raw.githubusercontent.com/enjoy-digital/litex/master/litex_setup.py
           python3 litex_setup.py gcc
-          sudo mkdir /usr/local/riscv
-          sudo cp -r $PWD/../riscv64-*/* /usr/local/riscv
 
       # Test
-      - name: Run Tests
+      - name: Build SoC
         run: |
-          export PATH=/usr/local/riscv/bin:$PATH
-          ./make.py --board=arty
+          export PATH=$PATH:~/.local/bin
+          export PATH=$PATH:$(realpath ../riscv64-*/bin)
+          git clean -dfx
+          ./make.py --board=${{ matrix.board }} ${{ matrix.args }}
+          git status
+
+      # Upload
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.board }}
+          path: build/*/gateware


### PR DESCRIPTION
This adds the groundwork for automatically building bitstreams via GitHub Actions. The artifacts are then available for download from the build page: https://github.com/jluebbe/linux-on-litex-vexriscv/actions/runs/847499253

Currently, the build fails for trellisboard, ecpix5 and de10nano, as the required cluster netlists are not in the https://github.com/litex-hub/pythondata-cpu-vexriscv_smp repository.