### PR TITLE
soc_linux.py: Add interrupt switches

### DIFF
--- a/soc_linux.py
+++ b/soc_linux.py
@@ -95,8 +95,9 @@ def SoCLinux(soc_cls, **kwargs):
 
         # Switches ---------------------------------------------------------------------------------
         def add_switches(self):
-            self.submodules.switches = GPIOIn(Cat(platform_request_all(self.platform, "user_sw")))
+            self.submodules.switches = GPIOIn(Cat(platform_request_all(self.platform, "user_sw")), with_irq=True)
             self.add_csr("switches")
+            self.add_interrupt("switches")
 
         # SPI --------------------------------------------------------------------------------------
         def add_spi(self, data_width, clk_freq):


### PR DESCRIPTION
That PR adds interrupt to switches in soc_linux.py and is associated with issue: https://github.com/litex-hub/linux-on-litex-vexriscv/issues/239