### PR TITLE
sim.py: set soc "config_earlycon" constant to "sbi"

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -209,6 +209,7 @@ def main():
                 soc.add_constant("LOCALIP{}".format(i+1), int(args.local_ip.split(".")[i]))
             for i in range(4):
                 soc.add_constant("REMOTEIP{}".format(i+1), int(args.remote_ip.split(".")[i]))
+        soc.add_constant("config_earlycon", "sbi")
         board_name = "sim"
         build_dir  = os.path.join("build", board_name)
         builder = Builder(soc, output_dir=build_dir,


### PR DESCRIPTION
This patch sets an soc configuration constant named "config_earlycon"
to "sbi" so that the dts generator sets "earlycon=sbi" in the dts file.

This is necessary for the simulation to send console output in a
timely manner.

Fixes: #258

See corresponding PR in litex for more: enjoy-digital/litex#1145