### PR TITLE
ulx3s: use spisdcard instead of sdcard

### DIFF
--- a/make.py
+++ b/make.py
@@ -347,7 +347,7 @@ class ULX3S(Board):
             # Communication
             "serial",
             # Storage
-            "sdcard",
+            "spisdcard",
             # Video,
             "framebuffer",
         }, bitstream_ext=".svf")


### PR DESCRIPTION
The ULX3S does not have a card detect (CD) pin for the SD interface,
which breaks the sdcard driver in Linux.

This patch changes the ULX3S to use the "spisdcard" interface instead
of the "sdcard" interface.  With this change the SD card works fine
from the BIOS and Linux in SPI-mode.

See also emard/ulx3s#15

Fixes: #203