### PR TITLE
use inferrable power of 2 memory size on Intel boards

### DIFF
--- a/make.py
+++ b/make.py
@@ -546,6 +546,7 @@ class De10Nano(Board):
     soc_kwargs = {
         "with_mister_sdram" : True, # Add MiSTer SDRAM extension.
         "l2_size"           : 2048, # Use Wishbone and L2 for memory accesses.
+        "integrated_sram_size": 0x1000, # Power of 2 so Quartus infers it properly.
     }
     def __init__(self):
         from litex_boards.targets import terasic_de10nano
@@ -564,7 +565,7 @@ class De10Nano(Board):
 class De0Nano(Board):
     soc_kwargs = {
         "l2_size" : 2048, # Use Wishbone and L2 for memory accesses.
-        "integrated_sram_size" : 0x800,
+        "integrated_sram_size": 0x1000, # Power of 2 so Quartus infers it properly.
     }
     def __init__(self):
         from litex_boards.targets import terasic_de0nano
@@ -576,7 +577,10 @@ class De0Nano(Board):
 # De1-SoC support ----------------------------------------------------------------------------------
 
 class De1SoC(Board):
-    soc_kwargs = {"l2_size" : 2048} # Use Wishbone and L2 for memory accesses.
+    soc_kwargs = {
+        "l2_size" : 2048, # Use Wishbone and L2 for memory accesses.
+        "integrated_sram_size": 0x1000, # Power of 2 so Quartus infers it properly.
+    }
     def __init__(self):
         from litex_boards.targets import terasic_de1soc
         Board.__init__(self, terasic_de1soc.BaseSoC, soc_capabilities={
@@ -593,7 +597,7 @@ class Qmtech_EP4CE15(Board):
     soc_kwargs = {
         "variant" : "ep4ce15",
         "l2_size" : 2048, # Use Wishbone and L2 for memory accesses.
-        "integrated_sram_size" : 0x800,
+        "integrated_sram_size": 0x1000, # Power of 2 so Quartus infers it properly.
     }
     def __init__(self):
         from litex_boards.targets import qmtech_ep4cex5
@@ -608,6 +612,7 @@ class Qmtech_EP4CE55(Board):
     soc_kwargs = {
         "variant" : "ep4ce55",
         "l2_size" :  2048, # Use Wishbone and L2 for memory accesses.
+        "integrated_sram_size": 0x1000, # Power of 2 so Quartus infers it properly.
     }
     def __init__(self):
         from litex_boards.targets import qmtech_ep4cex5
@@ -623,7 +628,7 @@ class Qmtech_5CEFA2(Board):
     soc_kwargs = {
         "variant" : "5cefa2",
         "l2_size" :  2048, # Use Wishbone and L2 for memory accesses.
-        "integrated_sram_size" : 0x800,
+        "integrated_sram_size": 0x1000, # Power of 2 so Quartus infers it properly.
     }
     def __init__(self):
         from litex_boards.targets import qmtech_5cefa2


### PR DESCRIPTION
For whatever reason, Quartus is unable to infer the integrated_sram memory when its size is not a power of two. This is confirmed using Quartus 20.1.1 and Quartus 18.1. As a result, these boards take excessively long to build and might not fit. The memory size has already been reduced on some of them in an attempt to fix this issue.

To fix this issue for all of them, the size on all Intel boards is reduced to the next lowest power of two. I've confirmed that all boards build, fit, and pass timing using Quartus 20.1.1. I've also confirmed that De10Nano can still boot the demo image.