### PR TITLE
Initial Ti180 dev kit support

### DIFF
--- a/make.py
+++ b/make.py
@@ -663,6 +663,21 @@ class TitaniumTi60F225DevKit(Board):
             "leds",
         })
 
+class TitaniumTi180M484DevKit(Board):
+    soc_kwargs = {
+        "sys_clk_freq"  : 200e6,
+    }
+    def __init__(self):
+        from litex_boards.targets import titanium_ti180_m484_dev_kit
+        Board.__init__(self, titanium_ti180_m484_dev_kit.BaseSoC, soc_capabilities={
+            # Communication
+            "serial",
+            # Storage
+            "sdcard",
+            # "spisdcard",
+            # GPIOs
+            "leds",
+        })
 #---------------------------------------------------------------------------------------------------
 # Build
 #---------------------------------------------------------------------------------------------------
@@ -718,6 +733,7 @@ supported_boards = {
     # Efinix
     "trion_t120_bga576_dev_kit"   : TrionT120BGA576DevKit,
     "titanium_ti60_f225_dev_kit"  : TitaniumTi60F225DevKit,
+    "titanium_ti180_m484_dev_kit"  : TitaniumTi180M484DevKit,
     }
 
 def main():
@@ -740,6 +756,7 @@ def main():
     parser.add_argument("--spi-data-width", default=8,   type=int,       help="SPI data width (max bits per xfer).")
     parser.add_argument("--spi-clk-freq",   default=1e6, type=int,       help="SPI clock frequency.")
     parser.add_argument("--fdtoverlays",    default="",                  help="Device Tree Overlays to apply.")
+    parser.add_argument("--initrd-size",    default=8*1048576, type=int, help="Size of initrd (default=8MB).")
     VexRiscvSMP.args_fill(parser)
     args = parser.parse_args()
 
@@ -861,7 +878,7 @@ def main():
         builder.build(run=args.build, build_name=board_name)
 
         # DTS --------------------------------------------------------------------------------------
-        soc.generate_dts(board_name)
+        soc.generate_dts(board_name, initrd_size=args.initrd_size)
         soc.compile_dts(board_name, args.fdtoverlays)
 
         # DTB --------------------------------------------------------------------------------------

--- a/soc_linux.py
+++ b/soc_linux.py
@@ -125,12 +125,12 @@ def SoCLinux(soc_cls, **kwargs):
             self.add_constant("REMOTEIP4", int(remote_ip[3]))
 
         # DTS generation ---------------------------------------------------------------------------
-        def generate_dts(self, board_name):
+        def generate_dts(self, board_name, **kwargs):
             json_src = os.path.join("build", board_name, "csr.json")
             dts = os.path.join("build", board_name, "{}.dts".format(board_name))
 
             with open(json_src) as json_file, open(dts, "w") as dts_file:
-                dts_content = generate_dts(json.load(json_file), polling=False)
+                dts_content = generate_dts(json.load(json_file), polling=False, **kwargs)
                 dts_file.write(dts_content)
 
         # DTS compilation --------------------------------------------------------------------------


### PR DESCRIPTION
Also solves the missing file problem, which was due to initrd size being default at 8MB, while user can have a larger rootfs.cpio.
So solution is to expose the `initrd-size` param of `generate_dts` to top.

BTW any ways to guard such cases? Any checking possible in bootloader code?