### PR TITLE
support for machdyne konfekt and noir

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ The current list of boards that have been tested and are supported can be obtain
     ├── icesugar_pro
     ├── kc705
     ├── kcu105
+    ├── machdyne_konfekt
+    ├── machdyne_noir
+    ├── machdyne_schoko
     ├── minispartan6
     ├── mnt_rkx7
     ├── netv2

--- a/make.py
+++ b/make.py
@@ -536,6 +536,40 @@ class Schoko(Board):
             "framebuffer",
         })
 
+# Konfekt support -----------------------------------------------------------------------------------
+class Konfekt(Board):
+    soc_kwargs = {"l2_size" : 0}
+    def __init__(self):
+        from litex_boards.targets import machdyne_konfekt
+        Board.__init__(self, machdyne_konfekt.BaseSoC, soc_capabilities={
+            # Communication
+            "serial",
+            "usb_host",
+            # Storage
+            #"spiflash",
+            "spisdcard",
+            #"sdcard",
+            # Video,
+            "framebuffer",
+        })
+
+# Noir support -----------------------------------------------------------------------------------
+class Noir(Board):
+    soc_kwargs = {"l2_size" : 8192}
+    def __init__(self):
+        from litex_boards.targets import machdyne_noir
+        Board.__init__(self, machdyne_noir.BaseSoC, soc_capabilities={
+            # Communication
+            "serial",
+            "usb_host",
+            # Storage
+            "spiflash",
+            "spisdcard",
+            #"sdcard",
+            # Video,
+            "framebuffer",
+        })
+
 #---------------------------------------------------------------------------------------------------
 # Intel Boards
 #---------------------------------------------------------------------------------------------------
@@ -711,6 +745,8 @@ supported_boards = {
     "colorlight_i5"               : Colorlight_i5,
     "icesugar_pro"                : IcesugarPro,
     "schoko"                      : Schoko,
+    "konfekt"                     : Konfekt,
+    "noir"                        : Noir,
 
     # Altera/Intel
     "de0nano"                     : De0Nano,


### PR DESCRIPTION
This adds support for Machdyne Konfekt and Noir which are now included in the litex-boards repo.

https://github.com/machdyne/konfekt
https://github.com/machdyne/noir