### PR TITLE
support for machdyne kopflos

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The current list of boards that have been tested and are supported can be obtain
     ├── kc705
     ├── kcu105
     ├── machdyne_konfekt
+    ├── machdyne_kopflos
     ├── machdyne_noir
     ├── machdyne_schoko
     ├── minispartan6

--- a/make.py
+++ b/make.py
@@ -585,6 +585,22 @@ class Noir(Board):
             "framebuffer",
         })
 
+# Kopflos support -----------------------------------------------------------------------------------
+class Kopflos(Board):
+    soc_kwargs = {"l2_size" : 0}
+    def __init__(self):
+        from litex_boards.targets import machdyne_kopflos
+        Board.__init__(self, machdyne_kopflos.BaseSoC, soc_capabilities={
+            # Communication
+            "serial",
+            "usb_host",
+            "ethernet",
+            # Storage
+            #"spiflash",
+            #"sdcard",
+            "spisdcard",
+        })
+
 #---------------------------------------------------------------------------------------------------
 # Intel Boards
 #---------------------------------------------------------------------------------------------------
@@ -763,6 +779,7 @@ supported_boards = {
     "schoko"                      : Schoko,
     "konfekt"                     : Konfekt,
     "noir"                        : Noir,
+    "kopflos"                     : Kopflos,
 
     # Altera/Intel
     "de0nano"                     : De0Nano,


### PR DESCRIPTION
This PR adds support for the [Kopflos](https://github.com/machdyne/kopflos) FPGA computer. The board is already supported by litex-boards.