### PR TITLE
Revert "Add support for the Alinx7020 board and enable access to its PS DDR."

### DIFF
--- a/boards.py
+++ b/boards.py
@@ -100,23 +100,6 @@ class ArtyS7(Board):
             "i2c",
         })
 
-# alinx support -------------------------------------------------------------------------------------
-
-class Ax7020(Board):
-    def __init__(self):
-        from litex_boards.targets import alinx_ax7020
-        Board.__init__(self, alinx_ax7020.BaseSoC, soc_capabilities={
-            # Communication
-            "serial",
-            #"ethernet",
-            # Storage
-            #"sdcard",
-            # GPIOs
-            "leds",
-            "buttons",
-            "ps_ddr",
-        })
-
 # NeTV2 support ------------------------------------------------------------------------------------
 
 class NeTV2(Board):

--- a/make.py
+++ b/make.py
@@ -122,8 +122,6 @@ def main():
             soc_kwargs.update(with_video_framebuffer=True)
         if "usb_host" in board.soc_capabilities:
             soc_kwargs.update(with_usb_host=True)
-        if "ps_ddr" in board.soc_capabilities:
-            soc_kwargs.update(with_ps_ddr=True)
 
         # SoC creation -----------------------------------------------------------------------------
         soc = SoCLinux(board.soc_cls, **soc_kwargs)


### PR DESCRIPTION
Reverts litex-hub/linux-on-litex-vexriscv#414

2025-03-10T11:04:30.3945445Z ======================================================================
2025-03-10T11:04:30.3946155Z FAIL: test_boards (test.test_build.TestBuild) [board=ax7020 build test...]
2025-03-10T11:04:30.3946882Z ----------------------------------------------------------------------
2025-03-10T11:04:30.3947218Z Traceback (most recent call last):
2025-03-10T11:04:30.3947756Z   File "/home/runner/work/linux-on-litex-vexriscv/linux-on-litex-vexriscv/test/test_build.py", line 39, in test_boards
2025-03-10T11:04:30.3948285Z     self.board_build_test(board=board)
2025-03-10T11:04:30.3948809Z   File "/home/runner/work/linux-on-litex-vexriscv/linux-on-litex-vexriscv/test/test_build.py", line 18, in board_build_test
2025-03-10T11:04:30.3949418Z     self.assertEqual(os.path.isfile(f"build/{board}/csr.csv"),  True)
2025-03-10T11:04:30.3949784Z AssertionError: False != True