### PR TITLE
Added initial colognechip_gatemate_evb support

### DIFF
--- a/boards.py
+++ b/boards.py
@@ -770,3 +770,18 @@ class Sipeed_tang_primer_20k(Board):
             "serial",
             "spisdcard",
         })
+
+#---------------------------------------------------------------------------------------------------
+# Gatemate Boards
+#---------------------------------------------------------------------------------------------------
+
+# CologneChip GateMate EVB support ---------------------------------------------------------------------
+
+class Colognechip_gatemate_evb(Board):
+    soc_kwargs = {"sys_clk_freq": int(24e6)}
+    def __init__(self):
+        from litex_boards.targets import colognechip_gatemate_evb
+        Board.__init__(self, colognechip_gatemate_evb.BaseSoC, soc_capabilities={
+            "serial",
+            "sdcard",
+        })

--- a/make.py
+++ b/make.py
@@ -142,6 +142,10 @@ def main():
             from litex_boards.platforms.avnet_aesku40 import _sdcard_pmod_io
             board.platform.add_extension(_sdcard_pmod_io)
 
+        if board_name in ["colognechip_gatemate_evb"]:
+            from litex_boards.platforms.colognechip_gatemate_evb import pmods_sdcard_io
+            board.platform.add_extension(pmods_sdcard_io("PMODA"))
+
         if board_name in ["orange_crab"]:
             from litex_boards.platforms.gsd_orangecrab import feather_i2c
             board.platform.add_extension(feather_i2c)


### PR DESCRIPTION
Added configuration for colognechip_gatemate_evb, note it does have 8MB of RAM.

This also requires https://github.com/litex-hub/litex-boards/pull/673 to be able to add SD card