### PR TITLE
Use --local-ip argument in SoC configuration

### DIFF
--- a/make.py
+++ b/make.py
@@ -113,7 +113,11 @@ def main():
         if "leds" in board.soc_capabilities:
             soc_kwargs.update(with_led_chaser=True)
         if "ethernet" in board.soc_capabilities:
-            soc_kwargs.update(with_ethernet=True)
+            soc_kwargs.update(
+                with_ethernet = True,
+                eth_ip        = args.local_ip,
+                remote_ip     = args.remote_ip,
+            )
         if "pcie" in board.soc_capabilities:
             soc_kwargs.update(with_pcie=True)
         if "spiflash" in board.soc_capabilities:
@@ -158,8 +162,6 @@ def main():
             soc.add_spi_sdcard()
         if "sdcard" in board.soc_capabilities:
             soc.add_sdcard()
-        if "ethernet" in board.soc_capabilities:
-            soc.configure_ethernet(remote_ip=args.remote_ip)
         #if "leds" in board.soc_capabilities:
         #    soc.add_leds()
         if "rgb_led" in board.soc_capabilities:

--- a/soc_linux.py
+++ b/soc_linux.py
@@ -55,22 +55,6 @@ def SoCLinux(soc_cls, **kwargs):
         def add_i2c(self):
             self.i2c0 = I2CMaster(self.platform.request("i2c", 0))
 
-        # Ethernet configuration -------------------------------------------------------------------
-
-        def configure_ethernet(self, remote_ip):
-            remote_ip = remote_ip.split(".")
-            try: # FIXME: Improve.
-                self.constants.pop("REMOTEIP1")
-                self.constants.pop("REMOTEIP2")
-                self.constants.pop("REMOTEIP3")
-                self.constants.pop("REMOTEIP4")
-            except:
-                pass
-            self.add_constant("REMOTEIP1", int(remote_ip[0]))
-            self.add_constant("REMOTEIP2", int(remote_ip[1]))
-            self.add_constant("REMOTEIP3", int(remote_ip[2]))
-            self.add_constant("REMOTEIP4", int(remote_ip[3]))
-
         # DTS generation ---------------------------------------------------------------------------
 
         def generate_dts(self, board_name, rootfs="ram0"):


### PR DESCRIPTION
See #424.
This PR takes the '--local-ip' argument into consideration when generating the SoC.

New 'netboot' command output:
```
litex> netboot

Booting from network...
Local IP: 10.138.242.37
Remote IP: 10.138.242.38
...
```