### PR TITLE
Fix import of SDRAM utilities from litedram.phy.model

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -25,8 +25,7 @@ from litex.soc.interconnect           import wishbone
 from litex.soc.cores.cpu.vexriscv_smp import VexRiscvSMP
 
 from litedram import modules as litedram_modules
-from litedram.phy.model       import SDRAMPHYModel
-from litex.tools.litex_sim    import sdram_module_nphases, get_sdram_phy_settings
+from litedram.phy.model       import SDRAMPHYModel, sdram_module_nphases, get_sdram_phy_settings
 from litedram.core.controller import ControllerSettings
 
 from liteeth.phy.model import LiteEthPHYModel


### PR DESCRIPTION
Moved imports of sdram_module_nphases and get_sdram_phy_settings from litex.tools.litex_sim to litedram.phy.model to correct the import source.

Since the updated litex package had moved these packages, this script should be moved, too.