### PR TITLE
make.py, soc_linux.py: delegates ethernet configuration to the target

### DIFF
--- a/make.py
+++ b/make.py
@@ -134,7 +134,11 @@ def main():
         if "leds" in board.soc_capabilities:
             soc_kwargs.update(with_led_chaser=True)
         if "ethernet" in board.soc_capabilities:
-            soc_kwargs.update(with_ethernet=True)
+            soc_kwargs.update({
+                "with_ethernet" : True,
+                "eth_ip"        : args.local_ip,
+                "remote_ip"     : args.remote_ip,
+            })
         if "pcie" in board.soc_capabilities:
             soc_kwargs.update(with_pcie=True)
         if "spiflash" in board.soc_capabilities:
@@ -179,8 +183,6 @@ def main():
             soc.add_spi_sdcard()
         if "sdcard" in board.soc_capabilities:
             soc.add_sdcard()
-        if "ethernet" in board.soc_capabilities:
-            soc.configure_ethernet(remote_ip=args.remote_ip)
         #if "leds" in board.soc_capabilities:
         #    soc.add_leds()
         if "rgb_led" in board.soc_capabilities:

--- a/soc_linux.py
+++ b/soc_linux.py
@@ -55,17 +55,6 @@ def SoCLinux(soc_cls, **kwargs):
         def add_i2c(self):
             self.i2c0 = I2CMaster(self.platform.request("i2c", 0))
 
-        # Ethernet configuration -------------------------------------------------------------------
-
-        def configure_ethernet(self, remote_ip):
-            remote_ip = remote_ip.split(".")
-            for k in ("REMOTEIP1", "REMOTEIP2", "REMOTEIP3", "REMOTEIP4"):
-                self.constants.pop(k, None)
-            self.add_constant("REMOTEIP1", int(remote_ip[0]))
-            self.add_constant("REMOTEIP2", int(remote_ip[1]))
-            self.add_constant("REMOTEIP3", int(remote_ip[2]))
-            self.add_constant("REMOTEIP4", int(remote_ip[3]))
-
         # DTS generation ---------------------------------------------------------------------------
 
         def generate_dts(self, board_name, rootfs="ram0"):


### PR DESCRIPTION
With recents commits in `litex-boards` the ethernet parameters are coherents.
So instead of ignoring `--local-ip` and using a custom method to honour `--remote-ip`, these two parameters are directly passed to the target cls to be used as done in a classic approach.
This PR also removes `configure_ethernet`  in `soc_linux.py` since this method is no more used.

This PR replaces #425.