### PR TITLE
buildroot: create genimage temporary directory before running dtc

### DIFF
--- a/buildroot/board/litex_vexriscv/post-image.sh
+++ b/buildroot/board/litex_vexriscv/post-image.sh
@@ -35,6 +35,7 @@ if [ ! -e $DST_DTB ]; then
 fi
 
 if [ -e $DST_DTB ]; then
+	mkdir -p "${GENIMAGE_TMP}"
 	DTB_DTS=${GENIMAGE_TMP}/rv32.dts
 	dtc -I dtb -O dts -o $DTB_DTS $DST_DTB
 	INITRD_START=$(sed -n -E 's/.*linux,initrd-start[[:space:]]*=[[:space:]]*<([^>]+)>.*/\1/p' $DTB_DTS | head -n 1)


### PR DESCRIPTION
`post-image.sh` decompiles `${DST_DTB}` to
`${GENIMAGE_TMP}/rv32.dts` without first ensuring that `${GENIMAGE_TMP}` exists.

During a clean Buildroot 2024.02.13 build, this causes the
`target-post-image` step to fail with:

```text
FATAL ERROR: Couldn't open output file
.../output/build/genimage.tmp/rv32.dts:
No such file or directory
```

This change ensures that `${GENIMAGE_TMP}` exists before invoking `dtc`.

Verified by rerunning the same RV32 VexRiscv SMP build configuration
for the Digilent Arty A7-35T. The build completed successfully and
generated `sdcard.img`.