### PR TITLE
buildroot: fix initrd size calculation for symlinked rootfs

### DIFF
--- a/buildroot/board/litex_vexriscv/post-image.sh
+++ b/buildroot/board/litex_vexriscv/post-image.sh
@@ -39,7 +39,7 @@ if [ -e $DST_DTB ]; then
 	dtc -I dtb -O dts -o $DTB_DTS $DST_DTB
 	INITRD_START=$(sed -n -E 's/.*linux,initrd-start[[:space:]]*=[[:space:]]*<([^>]+)>.*/\1/p' $DTB_DTS | head -n 1)
 	if [ -n "$INITRD_START" ]; then
-		INITRD_SIZE=$(stat -c%s $DST_ROOTFS_CPIO_GZ)
+		INITRD_SIZE=$(stat -Lc%s "$DST_ROOTFS_CPIO_GZ")
 		INITRD_END=$(printf "0x%x" $((INITRD_START + INITRD_SIZE)))
 		sed -i -E "s/(linux,initrd-end[[:space:]]*=[[:space:]]*<)0x[0-9a-fA-F]+(>)/\1${INITRD_END}\2/" $DTB_DTS
 		dtc -I dts -O dtb -o $DST_DTB $DTB_DTS


### PR DESCRIPTION
When `rootfs.cpio.gz` is available in the Buildroot output, `post-image.sh` creates `images/rootfs.cpio.gz` as a symbolic link to it. The subsequent `stat -c%s` reports the size of the symlink itself instead of the target archive, causing an incorrect `linux,initrd-end` value to be written to the DTB.

For example:

    $ stat -c%s images/rootfs.cpio.gz
    78

    $ stat -Lc%s images/rootfs.cpio.gz
    5594619

With `linux,initrd-start = <0x41000000>`, this resulted in:

    linux,initrd-end = <0x4100004e>;

and Linux stalled at:

    Waiting for root device /dev/ram0...

Use `stat -L` to dereference the symlink when calculating the initrd size. After the change, the generated DTB contains `linux,initrd-end = <0x41555dfb>`, which matches `0x41000000 + 5594619`.