### PR TITLE
linux: fix stale register maps in the litex-spiflash and litex-hwmon …

### DIFF
--- a/buildroot/patches/linux/6.9/0023-litex-spiflash-match-current-litespi-CSR-layout.patch
+++ b/buildroot/patches/linux/6.9/0023-litex-spiflash-match-current-litespi-CSR-layout.patch
@@ -1,0 +1,89 @@
+From: Richard Vodden <richard@vodden.com>
+Subject: [PATCH] mtd: spi-nor: litex-spiflash: match the current LiteSPI CSR layout
+
+The register offsets in this driver describe a LiteSPI core that LiteX no
+longer generates. Everything from master_cs onwards is shifted by 8, and two
+of the registers no longer exist. Current LiteX emits:
+
+    0x00  phy_clk_divisor
+    0x04  mmap_dummy_bits
+    0x08  master_cs
+    0x0c  master_phyconfig
+    0x10  master_rxtx
+    0x14  master_status
+
+whereas the driver used 0x00/0x04 then 0x10/0x14/0x18/0x1c/0x20.
+
+The practical effect is that litex_spiflash_tx() polls 0x1c for TX_READY.
+Nothing is mapped there, the bit never sets, and readx_poll_timeout() returns
+-ETIMEDOUT. That propagates out of spi_nor_scan(), so the flash is never
+identified and no MTD device is registered:
+
+    litex-spiflash f0004800.spiflash: SPI_NOR_SCAN FAILED
+    litex-spiflash f0004800.spiflash: probe with driver litex-spiflash failed
+                                      with error -110
+
+Two writes also landed on the wrong registers. Writing 0 to what the driver
+called PHY_MODE (0x04) actually clears mmap_dummy_bits, corrupting the
+memory-mapped read configuration; and the write to MASTER_CLK_DIVISOR (0x20)
+is past the end of the register block. Current LiteSPI has a single
+phy_clk_divisor and no separate master divisor, so that write is dropped
+rather than relocated, along with the now-unused local.
+
+Verified against the CSR map LiteX emits for an ALINX AX7035B: csr.csv gives
+spiflash_phy_clk_divisor 0xf0004800 through spiflash_master_status 0xf0004814.
+
+Signed-off-by: Richard Vodden <richard@vodden.com>
+---
+--- a/drivers/mtd/spi-nor/litex-spiflash.c	2026-08-13 20:40:44.354140242 +0000
++++ b/drivers/mtd/spi-nor/litex-spiflash.c	2026-08-13 20:40:44.464601046 +0000
+@@ -30,13 +30,17 @@
+ #include <linux/jiffies.h>
+ #include <linux/litex.h>
+ 
++/*
++ * LiteSPI CSR layout. Keep in sync with the csr.csv LiteX emits for the
++ * "spiflash" block: the offsets below changed when the core dropped its
++ * separate PHY mode and master clock divisor registers.
++ */
+ #define LITESPI_PHY_CLK_DIVISOR_OFFSET		0x00
+-#define LITESPI_PHY_MODE_OFFSET			0x04
+-#define LITESPI_MASTER_CS_OFFSET		0x10
+-#define LITESPI_MASTER_PHYCONFIG_OFFSET		0x14
+-#define LITESPI_MASTER_RXTX_OFFSET		0x18
+-#define LITESPI_MASTER_STATUS_OFFSET		0x1c
+-#define LITESPI_MASTER_CLK_DIVISOR_OFFSET	0x20
++#define LITESPI_MMAP_DUMMY_BITS_OFFSET		0x04
++#define LITESPI_MASTER_CS_OFFSET		0x08
++#define LITESPI_MASTER_PHYCONFIG_OFFSET		0x0c
++#define LITESPI_MASTER_RXTX_OFFSET		0x10
++#define LITESPI_MASTER_STATUS_OFFSET		0x14
+ 
+ #define LITESPI_PHYCONFIG_LEN_SHIFT		0
+ #define LITESPI_PHYCONFIG_WIDTH_SHIFT		8
+@@ -78,19 +82,20 @@
+ 
+ static void litex_spiflash_init(struct litex_spiflash *flash)
+ {
+-	u8 clk_divisor;
+ 	u32 phyconfig;
+ 
+-	clk_divisor = litex_read8(flash->base + LITESPI_PHY_CLK_DIVISOR_OFFSET);
+ 	phyconfig = LITESPI_PHYCONFIG_LEN(LITESPI_XFER_BITS) |
+ 		    LITESPI_PHYCONFIG_WIDTH(LITESPI_SINGLE_WIDTH) |
+ 		    LITESPI_PHYCONFIG_MASK(LITESPI_SINGLE_MOSI_MASK);
+ 
+-	litex_write8(flash->base + LITESPI_PHY_MODE_OFFSET, 0);
++	/*
++	 * Do not write 0x04 here: it used to be a PHY mode register but is now
++	 * mmap_dummy_bits, and clearing it corrupts the memory-mapped read
++	 * configuration. The core also has a single phy_clk_divisor and no
++	 * separate master divisor, so the divisor is left as configured.
++	 */
+ 	litex_write32(flash->base + LITESPI_MASTER_PHYCONFIG_OFFSET,
+ 		      phyconfig);
+-	litex_write8(flash->base + LITESPI_MASTER_CLK_DIVISOR_OFFSET,
+-		     clk_divisor);
+ 	litex_spiflash_set_cs(flash, false);
+ }
+ 

--- a/buildroot/patches/linux/6.9/0024-litex-hwmon-fix-XADC-register-offsets-for-32-bit-CSR.patch
+++ b/buildroot/patches/linux/6.9/0024-litex-hwmon-fix-XADC-register-offsets-for-32-bit-CSR.patch
@@ -1,0 +1,53 @@
+litex-hwmon: fix XADC register offsets
+
+The XADC voltage rails all read wrong values: VCCINT reported VCCAUX's
+reading, VCCAUX reported the unrelated `eoc' status register (so ~0 V),
+and VCCBRAM read past the end of the CSR block entirely.
+
+The driver hardcoded the CSRs as 8 bytes apart:
+
+    TEMP 0x0   VCCINT 0x8   VCCAUX 0x10   VCCBRAM 0x18
+
+but each is a 16-bit CSR, and LiteX packs a 16-bit CSR into a single
+subregister -- _litex_num_subregs(2) == 1 -- so consecutive CSRs are
+LITEX_SUBREG_SIZE (4 bytes) apart. Confirmed against a generated csr.csv:
+
+    xadc_temperature 0xf0008800
+    xadc_vccint      0xf0008804
+    xadc_vccaux      0xf0008808
+    xadc_vccbram     0xf000880c
+    xadc_eoc         0xf0008810
+
+Temperature is at offset 0 under either assumption, which is why it kept
+working and hid the problem.
+
+Derive the offsets from LITEX_SUBREG_SIZE rather than restating a stride
+that has to be kept in sync by hand.
+
+Signed-off-by: Richard Vodden <richard@vodden.com>
+--- a/drivers/hwmon/litex-hwmon.c
++++ b/drivers/hwmon/litex-hwmon.c
+@@ -22,13 +22,19 @@
+ #include <linux/hwmon.h>
+ #include <linux/litex.h>
+ 
+-#define TEMP_REG_OFFSET               0x0
++/*
++ * Each of these CSRs is 16 bits wide, so LiteX packs it into a single subregister --
++ * _litex_num_subregs(2) == 1 -- and consecutive CSRs are therefore LITEX_SUBREG_SIZE (4 bytes)
++ * apart, not 8. Deriving the offsets from the header constant keeps them correct rather than
++ * restating a stride that has to be kept in sync by hand.
++ */
++#define TEMP_REG_OFFSET               (0 * LITEX_SUBREG_SIZE)
+ #define TEMP_REG_SIZE                 2
+-#define VCCINT_REG_OFFSET             0x8
++#define VCCINT_REG_OFFSET             (1 * LITEX_SUBREG_SIZE)
+ #define VCCINT_REG_SIZE               2
+-#define VCCAUX_REG_OFFSET             0x10
++#define VCCAUX_REG_OFFSET             (2 * LITEX_SUBREG_SIZE)
+ #define VCCAUX_REG_SIZE               2
+-#define VCCBRAM_REG_OFFSET            0x18
++#define VCCBRAM_REG_OFFSET            (3 * LITEX_SUBREG_SIZE)
+ #define VCCBRAM_REG_SIZE              2
+ 
+ #define CHANNEL_TEMP                  0


### PR DESCRIPTION
…drivers

Both drivers describe a LiteX that is no longer generated, and both fail the same way: the first register happens to be at the right offset, so the peripheral looks like it works and only the later values are wrong.

litex-spiflash. Everything from master_cs onwards is shifted by 8 and two registers no longer exist. Current LiteSPI emits phy_clk_divisor 0x00, mmap_dummy_bits 0x04, master_cs 0x08, master_phyconfig 0x0c, master_rxtx 0x10, master_status 0x14, whereas the driver used 0x00/0x04 then 0x10..0x20. The practical effect is that litex_spiflash_tx() polls 0x1c for TX_READY, nothing is mapped there, and readx_poll_timeout() returns -ETIMEDOUT out of spi_nor_scan(), so no MTD device is ever registered. Two writes also landed on the wrong registers: the write of 0 to what the driver called PHY_MODE actually cleared mmap_dummy_bits, corrupting the memory-mapped read configuration.

litex-hwmon. The XADC CSRs are hardcoded 8 bytes apart, but each is a 16-bit CSR and LiteX packs those into a single 32-bit subregister, so they are LITEX_SUBREG_SIZE apart. VCCINT reported VCCAUX's reading, VCCAUX reported the eoc status register and VCCBRAM read past the end of the block. The offsets are now derived from LITEX_SUBREG_SIZE.

Both were found by comparing the drivers against a csr.csv generated for an ALINX AX7035B, and verified on that board: /dev/mtd0 appears and its contents match a JTAG dump byte for byte, and the three XADC rails read their expected values.

The other LiteX drivers here were audited the same way, against a csr.csv generated for the same SoC. liteuart, i2c-litex and gpio-litex are correct; litex_mmc and litex_liteeth are correct in every offset they use, including all seventeen registers of liteeth's mac region and litex_mmc's four-subregister cmd_response. Two definitions are stale but dead and are left for a separate cleanup: litex_mmc's LITEX_PHY_WRITESTATUS (0x0c, should be 0x10, displaced by the cmdr_timeout and datar_timeout registers LiteSDCard gained) and litex_liteeth's LITEETH_MDIO_R (0x0c, should be 0x08). Neither is referenced, and both live in mainline drivers rather than in this series.